### PR TITLE
refactor: use serde::from_reader, use Default, and shorten imports

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -4,8 +4,6 @@ on:
     paths:
       - 'cli/**/*.rs'
   pull_request: null
-env:
-  RUSTFLAGS: "-Dwarnings"
 jobs:
   lint_format:
     runs-on: ubuntu-latest

--- a/cli/src/commands/add_command.rs
+++ b/cli/src/commands/add_command.rs
@@ -1,8 +1,12 @@
-use crate::config;
-use crate::preflights::add::{PreflightAdd, preflight_add};
+use crate::{
+    config,
+    preflights::add::{PreflightAdd, preflight_add},
+};
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::{
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -58,10 +62,10 @@ pub enum RegistryType {
 impl Display for RegistryType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            RegistryType::Block => write!(f, "registry:block"),
-            RegistryType::Component => write!(f, "registry:component"),
-            RegistryType::UI => write!(f, "registry:ui"),
-            RegistryType::Style => write!(f, "registry:style"),
+            Self::Block => write!(f, "registry:block"),
+            Self::Component => write!(f, "registry:component"),
+            Self::UI => write!(f, "registry:ui"),
+            Self::Style => write!(f, "registry:style"),
         }
     }
 }

--- a/cli/src/commands/init_command.rs
+++ b/cli/src/commands/init_command.rs
@@ -1,7 +1,8 @@
-use crate::config::{Config, ConfigError};
-use crate::preflights::init::{PreflightInitErrors, preflight_init};
 use crate::{
-    NPM, inc_step,
+    NPM,
+    config::{Config, ConfigError},
+    inc_step,
+    preflights::init::{PreflightInitErrors, preflight_init},
     util::step::{LOOKING_GLASS, PAPER, SPARKLE, Step, TRUCK, step},
 };
 use console::style;
@@ -9,11 +10,13 @@ use dialoguer::Confirm;
 use indicatif::{MultiProgress, style::TemplateError};
 use log::error;
 use serde::{Deserialize, Serialize};
-use std::env::current_dir;
-use std::fs::File;
-use std::io::BufWriter;
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::{
+    env::current_dir,
+    fs::File,
+    io::BufWriter,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -97,7 +100,7 @@ fn generate_components_json(options: &InitSchema) -> Result<(), InitError> {
 
     let file = File::create(options.cwd.join("components.json"))?;
     let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, &Config::new())?;
+    serde_json::to_writer_pretty(writer, &Config::default())?;
 
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,14 @@
-use crate::commands::add_command::{AddSchema, add_command};
-use crate::commands::init_command::{InitSchema, init_command};
+use crate::commands::{
+    add_command::{AddSchema, add_command},
+    init_command::{InitSchema, init_command},
+};
 use cfg_if::cfg_if;
-use clap::ArgAction;
-use clap::ValueHint;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueHint};
 use indicatif::MultiProgress;
 use indicatif_log_bridge::LogWrapper;
 use log::error;
 use reqwest::Client;
-use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::{path::PathBuf, sync::LazyLock};
 use thiserror::Error;
 
 mod commands;

--- a/cli/src/preflights/init.rs
+++ b/cli/src/preflights/init.rs
@@ -1,10 +1,10 @@
-use crate::commands::init_command::InitSchema;
-use crate::util::get_project_info::get_project_info;
-use crate::util::spinner::Spinner;
+use crate::{
+    commands::init_command::InitSchema,
+    util::{get_project_info::get_project_info, spinner::Spinner},
+};
 use console::{StyledObject, style};
 use log::error;
-use std::fmt::Debug;
-use std::fs;
+use std::{fmt::Debug, fs};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/cli/src/util/get_package_info.rs
+++ b/cli/src/util/get_package_info.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::{collections::BTreeMap, fs::File, io::BufReader, path::Path};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -137,10 +134,7 @@ pub struct FundingSingle {
 pub fn get_package_info(cwd: &Path) -> Option<PackageJson> {
     let package_json_path = cwd.join("package.json");
 
-    File::open(&package_json_path).ok().map(|mut f| {
-        let mut contents = String::new();
-        f.read_to_string(&mut contents).expect("Reading package.json");
-
-        serde_json::from_str::<PackageJson>(&contents).unwrap()
-    })
+    File::open(&package_json_path)
+        .ok()
+        .map(|f| serde_json::from_reader::<_, PackageJson>(BufReader::new(f)).unwrap())
 }

--- a/cli/src/util/get_package_manager.rs
+++ b/cli/src/util/get_package_manager.rs
@@ -1,7 +1,8 @@
 use crate::util::get_package_info::get_package_info;
-use std::env;
-use std::env::current_dir;
-use std::path::Path;
+use std::{
+    env::{self, current_dir},
+    path::Path,
+};
 
 pub enum PackageRunners {
     PnpmDlx,
@@ -27,35 +28,26 @@ pub struct PackageManager {
 impl PackageRunners {
     pub fn as_str(&self) -> &'static str {
         match self {
-            PackageRunners::PnpmDlx => "pnpm dlx",
-            PackageRunners::Bunx => "bunx",
-            PackageRunners::Npx => "npx",
-            PackageRunners::YarnDlx => "yarn dlx",
+            Self::PnpmDlx => "pnpm dlx",
+            Self::Bunx => "bunx",
+            Self::Npx => "npx",
+            Self::YarnDlx => "yarn dlx",
         }
     }
 }
 
 // TODO: Eventually detect from lock file & possibly PATH later on.
 pub fn get_package_manager(cwd: &Path) -> Option<PackageManager> {
-    if let Some(pm) = detect_from_user_agent() {
-        return Some(pm);
-    }
-    if let Some(pm) = detect_from_package_json() {
-        return Some(pm);
-    }
-
-    None
+    detect_from_user_agent().or_else(detect_from_package_json)
 }
 
 pub fn get_package_runner(cwd: &Path) -> Option<PackageRunners> {
-    let package_manager = get_package_manager(cwd)?;
-
-    match package_manager.kind {
-        PackageManagerKind::Npm => Some(PackageRunners::Npx),
-        PackageManagerKind::Yarn => Some(PackageRunners::YarnDlx),
-        PackageManagerKind::Pnpm => Some(PackageRunners::PnpmDlx),
-        PackageManagerKind::Bun => Some(PackageRunners::Bunx),
-    }
+    get_package_manager(cwd).map(|package_manager| match package_manager.kind {
+        PackageManagerKind::Npm => PackageRunners::Npx,
+        PackageManagerKind::Yarn => PackageRunners::YarnDlx,
+        PackageManagerKind::Pnpm => PackageRunners::PnpmDlx,
+        PackageManagerKind::Bun => PackageRunners::Bunx,
+    })
 }
 
 fn detect_from_user_agent() -> Option<PackageManager> {

--- a/cli/src/util/get_project_info.rs
+++ b/cli/src/util/get_project_info.rs
@@ -1,8 +1,10 @@
 use log::error;
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TsAliasError {
@@ -58,24 +60,13 @@ pub fn get_ts_config_alias_prefix(cwd: &Path) -> Result<Option<String>, TsAliasE
         return Ok(None);
     };
 
-    if paths_map.is_empty() {
-        return Ok(None);
-    };
-
     const CANDIDATES: &[&str] = &["./*", "./src/*"];
 
-    for (alias, targets) in &paths_map {
-        let hits_candidate = targets.iter().any(|t| CANDIDATES.iter().any(|c| t == c));
-        if hits_candidate {
-            return Ok(Some(trim_alias_suffix(alias.as_str())));
-        }
-    }
-
-    if let Some(first_key) = paths_map.keys().next() {
-        return Ok(Some(trim_alias_suffix(first_key.as_str())));
-    }
-
-    Ok(None)
+    Ok(paths_map
+        .iter()
+        .find(|(_, targets)| targets.iter().any(|t| CANDIDATES.iter().any(|c| t == c)))
+        .map(|(alias, _)| trim_alias_suffix(alias.as_str()))
+        .or_else(|| paths_map.keys().next().map(|first_key| trim_alias_suffix(first_key.as_str()))))
 }
 
 fn trim_alias_suffix(alias: &str) -> String {


### PR DESCRIPTION
The following pull request removes the unnecessary usage of `serde::from_str` by directly passing the stream onto `serde::from_reader`, uses the `Default` trait where constructors don't need an argument and don't return an `Option`/`Result` type, and combines imports together to make them cleaner.

Other changes were also made, such as optimizing several functions by making use of Rust's built-in methods over a more manual approach.